### PR TITLE
add locales_default.language `LANGUAGE= ` variable

### DIFF
--- a/templates/etc/default/locale.j2
+++ b/templates/etc/default/locale.j2
@@ -1,6 +1,9 @@
 # {{ ansible_managed }}
 
 LANG="{{ locales_default.lang }}"
+{% if locales_default.language is defined %}
+LANGUAGE="{{ locales_default.language }}"
+{% endif %}
 {% if locales_default.lc_address is defined %}
 LC_ADDRESS="{{ locales_default.lc_address }}"
 {% endif %}


### PR DESCRIPTION
I would suggest to add `LANGUAGE=`  to `/etc/default/locale`. 

I'm used to setting this on my Debian servers.

https://github.com/Oefenweb/ansible-locales/issues/4