### PR TITLE
port to ansible 2.7.0

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,27 +2,24 @@
 ---
 - name: install
   apt:
-    name: "{{ item }}"
+    name: "{{ locales_dependencies }}"
     state: "{{ apt_install_state | default('latest') }}"
     update_cache: true
     cache_valid_time: "{{ apt_update_cache_valid_time | default(3600) }}"
-  with_items: "{{ locales_dependencies }}"
   tags: [configuration, locales, locales-install]
 
 - name: install (specified) language packs
   apt:
-    name: "{{ item }}"
+    name: "{{ locales_language_packs_present }}"
     state: "{{ apt_install_state | default('latest') }}"
-  with_items: "{{ locales_language_packs_present }}"
   when: ansible_distribution == 'Ubuntu'
   notify: update locales
   tags: [configuration, locales, locales-language-packs-present]
 
 - name: remove (specified) language packs
   apt:
-    name: "{{ item }}"
+    name: "{{ locales_language_packs_absent }}"
     state: absent
-  with_items: "{{ locales_language_packs_absent }}"
   when: ansible_distribution == 'Ubuntu'
   notify: update locales
   tags: [configuration, locales, locales-language-packs-absent]


### PR DESCRIPTION
Remove warning with ansible 2.7.0
Comply with ansible 2.7.0 requirements for ansible 2.7.0 regarding packages and squash_actions.