### PR TITLE
fix ubuntu-1804 hangs on on SSH auth method: private key

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,7 +30,7 @@ boxes = [
     :box => "bento/ubuntu-18.04",
     :ip => '10.0.0.14',
     :cpu => "50",
-    :ram => "256"
+    :ram => "384"
   },
   {
     :name => "debian-7",

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,7 +46,7 @@
   file:
     path: "{{ locales_gen_file }}"
     state: touch
-  when: _locales_gen_file_stats.stat.exists == false
+  when: not _locales_gen_file_stats.stat.exists
   tags:
     - configuration
     - locales


### PR DESCRIPTION
The VM needs more than 256 MB RAM.  The error message with 256 MB is

```
Bringing machine 'ubuntu-1804' up with 'virtualbox' provider...
==> ubuntu-1804: Importing base box 'bento/ubuntu-18.04'...
==> ubuntu-1804: Matching MAC address for NAT networking...
==> ubuntu-1804: Checking if box 'bento/ubuntu-18.04' version '202002.04.0' is up to date...
==> ubuntu-1804: Setting the name of the VM: locales_ubuntu-1804_1581425842195_29616
==> ubuntu-1804: Clearing any previously set network interfaces...
==> ubuntu-1804: Preparing network interfaces based on configuration...
    ubuntu-1804: Adapter 1: nat
    ubuntu-1804: Adapter 2: hostonly
==> ubuntu-1804: Forwarding ports...
    ubuntu-1804: 22 (guest) => 2222 (host) (adapter 1)
==> ubuntu-1804: Running 'pre-boot' VM customizations...
==> ubuntu-1804: Booting VM...
==> ubuntu-1804: Waiting for machine to boot. This may take a few minutes...
    ubuntu-1804: SSH address: 127.0.0.1:2222
    ubuntu-1804: SSH username: vagrant
    ubuntu-1804: SSH auth method: private key
...
```

And the action abort with a timeout.

