### PR TITLE
fix: Don't compare to literal True/False

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,7 +46,7 @@
   file:
     path: "{{ locales_gen_file }}"
     state: touch
-  when: _locales_gen_file_stats.stat.exists == false
+  when: not _locales_gen_file_stats.stat.exists
   tags:
     - configuration
     - locales


### PR DESCRIPTION
fix build for latest version of Ansible

The error message is:

```
$ if [ "$ANSIBLE_VERSION" = "latest" ]; then ansible-lint tests/test.yml; fi
[601] Don't compare to literal True/False
tasks/main.yml:49
  when: _locales_gen_file_stats.stat.exists == false
The command "if [ "$ANSIBLE_VERSION" = "latest" ]; then ansible-lint tests/test.yml; fi" exited with 2.
```
