### PR TITLE
Add debian 10

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -53,6 +53,13 @@ boxes = [
     :cpu => "50",
     :ram => "256"
   },
+  {
+    :name => "debian-10",
+    :box => "bento/debian-10",
+    :ip => '10.0.0.18',
+    :cpu => "50",
+    :ram => "256"
+  },
 ]
 
 Vagrant.configure("2") do |config|

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,6 +19,7 @@ galaxy_info:
         - wheezy
         - jessie
         - stretch
+        - buster
   galaxy_tags:
     - system
 dependencies: []


### PR DESCRIPTION
Add Debian 10 (Buster) to supported distros.