### PR TITLE
Fix idempotence on ubuntu 16.04-20.04

### DIFF
--- a/templates/etc/default/locale.j2
+++ b/templates/etc/default/locale.j2
@@ -1,6 +1,5 @@
 # {{ ansible_managed }}
-
-LANG="{{ locales_default.lang }}"
+LANG={{ locales_default.lang }}
 {% if locales_default.language is defined %}
 LANGUAGE="{{ locales_default.language }}"
 {% endif %}


### PR DESCRIPTION
Line break in template causes idempotence issue.

I tested with molecule.

You can compare travis builds, [before ](https://travis-ci.org/github/viasite-ansible/ansible-role-locales/builds/681946289) and [after](https://travis-ci.org/github/viasite-ansible/ansible-role-locales/builds/681947668).

https://github.com/Oefenweb/ansible-locales/issues/8