### PR TITLE
Add Ubuntu 22.04 (jammy) to supported distros

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
           - distro: ubuntu1604
           - distro: ubuntu1804
           - distro: ubuntu2004
+          - distro: ubuntu2204
 
     steps:
       - name: Check out the codebase

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,6 +26,13 @@ boxes = [
     :ram => "384"
   },
   {
+    :name => "ubuntu-2204",
+    :box => "bento/ubuntu-22.04",
+    :ip => '10.0.0.15',
+    :cpu => "50",
+    :ram => "512"
+  },
+  {
     :name => "debian-8",
     :box => "bento/debian-8",
     :ip => '10.0.0.16',

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,6 +14,7 @@ galaxy_info:
         - xenial
         - bionic
         - focal
+        - jammy
     - name: Debian
       versions:
         - jessie


### PR DESCRIPTION
Tested with several locales
VM needs 512 MB RAM to boot